### PR TITLE
v54: 重整天氣預報資料品質，避免顯示過期或誤導的預報

### DIFF
--- a/app.js
+++ b/app.js
@@ -210,19 +210,23 @@
   if (fxTwd) fxTwd.addEventListener('input', onTwdInput);
   if (fxRate) fetchRate();
 
-  async function loadWeather() {
+  async function loadWeather(opts) {
     const box = document.getElementById('weather-days');
     if (!box) return;
-    const WEATHER_KEY = 'weather-sgn-v1';
-    const url = 'https://api.open-meteo.com/v1/forecast?latitude=10.7769&longitude=106.7009&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=Asia%2FBangkok&start_date=2026-05-01&end_date=2026-05-05';
+    const force = !!(opts && opts.force);
+    const WEATHER_KEY = 'weather-sgn-v2';
+    const url = 'https://api.open-meteo.com/v1/forecast?latitude=10.7769&longitude=106.7009&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max,precipitation_sum&timezone=Asia%2FBangkok&start_date=2026-05-01&end_date=2026-05-05&models=best_match';
     const emojiFor = (c) => {
       if (c === 0) return '☀️';
-      if (c <= 3) return '⛅';
-      if (c <= 48) return '🌫️';
-      if (c <= 57) return '🌦️';
-      if (c <= 67) return '🌧️';
-      if (c <= 77) return '❄️';
-      if (c <= 82) return '🌧️';
+      if (c === 1) return '🌤️';
+      if (c === 2) return '⛅';
+      if (c === 3) return '☁️';
+      if (c === 45 || c === 48) return '🌫️';
+      if (c >= 51 && c <= 57) return '🌦️';
+      if (c >= 61 && c <= 67) return '🌧️';
+      if (c >= 71 && c <= 77) return '❄️';
+      if (c >= 80 && c <= 82) return '🌧️';
+      if (c >= 85 && c <= 86) return '🌨️';
       if (c >= 95) return '⛈️';
       return '☁️';
     };
@@ -235,33 +239,53 @@
       return mo + '/' + d + ' ' + ZH_WEEKDAYS[dow];
     }
 
-    function render(daily, cached) {
+    function fmtMm(v) {
+      if (v == null || isNaN(v)) return '';
+      const n = Number(v);
+      if (n <= 0) return '';
+      if (n < 1) return n.toFixed(1) + 'mm';
+      return Math.round(n) + 'mm';
+    }
+    function fmtUpdated(ts) {
+      const d = new Date(ts);
+      const hh = String(d.getHours()).padStart(2, '0');
+      const mm = String(d.getMinutes()).padStart(2, '0');
+      return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + hh + ':' + mm;
+    }
+    function render(daily, cached, ts) {
       if (!daily || !daily.time) { box.textContent = '無天氣資料'; return; }
       let html = '';
       for (let i = 0; i < daily.time.length; i++) {
         const tmax = Math.round(daily.temperature_2m_max[i]);
         const tmin = Math.round(daily.temperature_2m_min[i]);
-        const rain = daily.precipitation_probability_max[i] || 0;
+        const rainP = daily.precipitation_probability_max ? (daily.precipitation_probability_max[i] || 0) : 0;
+        const rainMm = daily.precipitation_sum ? daily.precipitation_sum[i] : null;
+        const mmStr = fmtMm(rainMm);
         html +=
           '<div class="weather-day">' +
             '<div class="wd-name">' + weekdayLabel(daily.time[i]) + '</div>' +
             '<div class="wd-emoji">' + emojiFor(daily.weather_code[i]) + '</div>' +
             '<div class="wd-temp">' + tmin + '° / ' + tmax + '°</div>' +
-            '<div class="wd-rain">💧' + rain + '%</div>' +
+            '<div class="wd-rain">💧' + rainP + '%' + (mmStr ? ' · ' + mmStr : '') + '</div>' +
           '</div>';
       }
-      if (cached) html += '<div class="wd-cached">離線快取資料</div>';
+      const stampStr = ts ? '更新 ' + fmtUpdated(ts) : '';
+      const cachedStr = cached ? '離線快取資料' : '';
+      const meta = [stampStr, cachedStr].filter(Boolean).join(' · ');
+      if (meta) html += '<div class="wd-cached">' + meta + '</div>';
       box.innerHTML = html;
-      // === Rain alert: prepend warning to days with >60% rain forecast ===
+      // === Rain alert: prepend warning to days with >60% probability OR >5mm forecast rain ===
       document.querySelectorAll('.rain-alert').forEach((el) => el.remove());
       for (let i = 0; i < daily.time.length; i++) {
-        const rain = daily.precipitation_probability_max[i] || 0;
-        if (rain < 60) continue;
+        const rainP = daily.precipitation_probability_max ? (daily.precipitation_probability_max[i] || 0) : 0;
+        const rainMm = daily.precipitation_sum ? Number(daily.precipitation_sum[i] || 0) : 0;
+        if (rainP < 60 && rainMm < 5) continue;
         const day = document.querySelector('details[data-date="' + daily.time[i] + '"]');
         if (!day) continue;
         const alert = document.createElement('div');
         alert.className = 'rain-alert';
-        alert.innerHTML = '⚠️ 預報雨機率 <strong>' + rain + '%</strong>。建議優先選室內活動或備傘 — <a href="#main">看備用方案</a>。';
+        const mmTxt = rainMm >= 1 ? '，預估雨量 <strong>' + Math.round(rainMm) + 'mm</strong>' : '';
+        alert.innerHTML = '⚠️ 預報雨機率 <strong>' + rainP + '%</strong>' + mmTxt + '。建議優先選室內活動或備傘 — <a href="#main">看備用方案</a>。';
         const summary = day.querySelector(':scope > summary');
         if (summary && summary.nextSibling) {
           day.insertBefore(alert, summary.nextSibling);
@@ -271,24 +295,41 @@
       }
     }
 
+    if (!force) {
+      try {
+        const cached = JSON.parse(localStorage.getItem(WEATHER_KEY) || 'null');
+        if (cached && cached.daily) render(cached.daily, false, cached.ts || 0);
+      } catch (err) {}
+    }
+
     try {
       const r = await fetch(url, { cache: 'no-store' });
       const data = await r.json();
       if (data && data.daily) {
-        try { localStorage.setItem(WEATHER_KEY, JSON.stringify({ daily: data.daily, ts: Date.now() })); } catch (e) {}
-        render(data.daily, false);
+        const ts = Date.now();
+        try { localStorage.setItem(WEATHER_KEY, JSON.stringify({ daily: data.daily, ts: ts })); } catch (e) {}
+        render(data.daily, false, ts);
         return;
       }
       throw new Error('no data');
     } catch (e) {
       try {
         const cached = JSON.parse(localStorage.getItem(WEATHER_KEY) || 'null');
-        if (cached && cached.daily) { render(cached.daily, true); return; }
+        if (cached && cached.daily) { render(cached.daily, true, cached.ts || 0); return; }
       } catch (err) {}
-      box.textContent = '天氣暫時無法載入';
+      if (!box.innerHTML || box.textContent === '載入中…') box.textContent = '天氣暫時無法載入';
     }
   }
   loadWeather();
+  const weatherRefreshBtn = document.getElementById('weather-refresh');
+  if (weatherRefreshBtn) {
+    weatherRefreshBtn.addEventListener('click', () => {
+      try { localStorage.removeItem('weather-sgn-v2'); } catch (e) {}
+      const box = document.getElementById('weather-days');
+      if (box) box.textContent = '載入中…';
+      loadWeather({ force: true });
+    });
+  }
 
   // === IG recommendation icons ===
   // 若你有特定的 IG 貼文 / Reel URL，在此 map 填入 '地點名稱': 'IG_URL' 即可覆蓋

--- a/app.js
+++ b/app.js
@@ -634,21 +634,35 @@
     const byName = members.find((m) => m.name === payer);
     return byName ? byName.id : getSelfMember().id;
   }
-  // Migrate legacy entries: payer free-text → member id (auto-create members)
+  // Migrate legacy entries: payer free-text → member id (auto-create members);
+  // also derive `participants` from `splitCount` so settlement can be computed.
   (function migrateLegacy() {
     let changed = false;
     spending.forEach((e) => {
-      if (!e.payer) { e.payer = getSelfMember().id; changed = true; return; }
-      if (e.payer === '__multi__' || e.payer.startsWith('m-') && getMember(e.payer)) return;
-      // legacy free-text
-      let m = members.find((x) => x.name === e.payer);
-      if (!m) {
-        m = { id: genMemberId(), name: String(e.payer).slice(0, 15) };
-        members.push(m);
+      if (!e.payer) { e.payer = getSelfMember().id; changed = true; }
+      else if (e.payer !== '__multi__' && !(e.payer.startsWith('m-') && getMember(e.payer))) {
+        // legacy free-text payer name
+        let m = members.find((x) => x.name === e.payer);
+        if (!m) {
+          m = { id: genMemberId(), name: String(e.payer).slice(0, 15) };
+          members.push(m);
+        }
+        e.payer = m.id;
         changed = true;
       }
-      e.payer = m.id;
-      changed = true;
+      // Derive participants from splitCount if missing.
+      // Only feasible when splitCount fits within current members (else settlement
+      // skips the entry — too ambiguous to retroactively guess who else was there).
+      if (!Array.isArray(e.participants) || e.participants.length === 0) {
+        const split = Math.max(1, +e.splitCount || 1);
+        const selfId = getSelfMember().id;
+        const others = members.filter((m) => !m.isSelf).map((m) => m.id);
+        if (split <= 1 + others.length) {
+          e.participants = [selfId].concat(others.slice(0, split - 1));
+          e.splitCount = e.participants.length;
+          changed = true;
+        }
+      }
     });
     if (changed) { saveMembers(); saveSpending(); }
   })();
@@ -799,6 +813,7 @@
   function refreshAllUI() {
     renderMembersUI();
     renderPayerSelect();
+    renderSplitChips();
     updateMultiPayVisibility();
     renderSpending();
   }
@@ -817,9 +832,15 @@
     } else {
       payerHtml = '<span class="sp-payer-chip">👤 ' + escapeHtml(payerLabel(e.payer)) + '付</span>';
     }
-    const splitInfo = split > 1
-      ? '<span class="sp-split-mini">÷' + split + '人＝' + fmtVnd(Math.round(amt / split)) + '／人</span>'
-      : '';
+    let splitInfo = '';
+    if (split > 1) {
+      const share = Math.round(amt / split);
+      const names = (Array.isArray(e.participants) && e.participants.length)
+        ? e.participants.map((id) => { const m = getMember(id); return m ? m.name : ''; }).filter(Boolean)
+        : null;
+      const who = names && names.length ? '（' + escapeHtml(names.join('、')) + '）' : '';
+      splitInfo = '<span class="sp-split-mini">÷' + split + '人' + who + '＝' + fmtVnd(share) + '／人</span>';
+    }
     const noteHtml = e.note ? '<span class="sp-note-mini">＃' + escapeHtml(e.note) + '</span>' : '';
     const editingCls = realIdx === editingIdx ? ' sp-card-editing' : '';
     const twdLine = (typeof rate === 'number' && rate && amt)
@@ -844,6 +865,121 @@
       '</div>' +
     '</div>';
   }
+  // Compute pairwise net settlement.
+  // Returns: { netOwes: { creditorId: { debtorId: vndAmount } }, skipped: number }
+  // skipped = entries where participants couldn't be derived (legacy + ambiguous).
+  function computeSettlement() {
+    const pair = {}; // pair[A][B] = how much B owes A in raw debts
+    let skipped = 0;
+    function addOwe(creditor, debtor, amount) {
+      if (creditor === debtor || !(amount > 0)) return;
+      if (!pair[creditor]) pair[creditor] = {};
+      pair[creditor][debtor] = (pair[creditor][debtor] || 0) + amount;
+    }
+    spending.forEach((e) => {
+      const amt = +e.amount || 0;
+      if (amt <= 0) return;
+      const participants = (Array.isArray(e.participants) && e.participants.length)
+        ? e.participants.filter((id) => getMember(id))
+        : null;
+      if (!participants || participants.length === 0) { skipped++; return; }
+      const share = amt / participants.length;
+      let payments;
+      if (e.payer === '__multi__' && e.paid) {
+        payments = {};
+        Object.keys(e.paid).forEach((id) => {
+          const v = +e.paid[id] || 0;
+          if (v > 0 && getMember(id)) payments[id] = v;
+        });
+      } else {
+        const payerId = (e.payer && getMember(e.payer)) ? e.payer : getSelfMember().id;
+        payments = {};
+        payments[payerId] = amt;
+      }
+      const totalPaid = Object.values(payments).reduce((s, v) => s + v, 0);
+      if (totalPaid <= 0) { skipped++; return; }
+      participants.forEach((pId) => {
+        const paidByThem = payments[pId] || 0;
+        const owedByThem = share - paidByThem;
+        if (owedByThem <= 0) return;
+        // Distribute their debt across payers proportionally to what each paid.
+        Object.keys(payments).forEach((payerId) => {
+          if (payerId === pId) return;
+          const portion = (payments[payerId] / totalPaid) * owedByThem;
+          addOwe(payerId, pId, portion);
+        });
+      });
+    });
+    // Net out reciprocal debts: if A owes B 100 and B owes A 30, net is A→B 70.
+    const netOwes = {};
+    const seen = new Set();
+    Object.keys(pair).forEach((a) => {
+      Object.keys(pair[a]).forEach((b) => {
+        const key = [a, b].sort().join('|');
+        if (seen.has(key)) return;
+        seen.add(key);
+        const ab = (pair[a] && pair[a][b]) || 0;
+        const ba = (pair[b] && pair[b][a]) || 0;
+        const net = ab - ba;
+        if (net > 0.5) {
+          if (!netOwes[a]) netOwes[a] = {};
+          netOwes[a][b] = Math.round(net);
+        } else if (net < -0.5) {
+          if (!netOwes[b]) netOwes[b] = {};
+          netOwes[b][a] = Math.round(-net);
+        }
+      });
+    });
+    return { netOwes: netOwes, skipped: skipped };
+  }
+  function renderSettlement() {
+    const box = document.getElementById('spending-settle');
+    if (!box) return;
+    if (members.length <= 1 || spending.length === 0) {
+      box.innerHTML = '';
+      box.hidden = true;
+      return;
+    }
+    const result = computeSettlement();
+    const selfId = getSelfMember().id;
+    const lines = [];
+    members.forEach((m) => {
+      if (m.isSelf) return;
+      const theyOweMe = (result.netOwes[selfId] && result.netOwes[selfId][m.id]) || 0;
+      const iOweThem  = (result.netOwes[m.id] && result.netOwes[m.id][selfId]) || 0;
+      const net = theyOweMe - iOweThem;
+      if (net > 0) {
+        const twd = (typeof rate === 'number' && rate)
+          ? ' <span class="sp-settle-twd">≈ NT$ ' + Math.round(net * rate).toLocaleString('en-US') + '</span>' : '';
+        lines.push('<li class="sp-settle-row sp-settle-credit">' +
+          '<span class="sp-settle-name">' + escapeHtml(m.name) + ' 還你</span>' +
+          '<span class="sp-settle-amount">' + fmtVnd(net) + ' VND' + twd + '</span>' +
+        '</li>');
+      } else if (net < 0) {
+        const owe = -net;
+        const twd = (typeof rate === 'number' && rate)
+          ? ' <span class="sp-settle-twd">≈ NT$ ' + Math.round(owe * rate).toLocaleString('en-US') + '</span>' : '';
+        lines.push('<li class="sp-settle-row sp-settle-debt">' +
+          '<span class="sp-settle-name">你給 ' + escapeHtml(m.name) + '</span>' +
+          '<span class="sp-settle-amount">' + fmtVnd(owe) + ' VND' + twd + '</span>' +
+        '</li>');
+      } else {
+        lines.push('<li class="sp-settle-row sp-settle-zero">' +
+          '<span class="sp-settle-name">' + escapeHtml(m.name) + '</span>' +
+          '<span class="sp-settle-amount">已結清</span>' +
+        '</li>');
+      }
+    });
+    if (lines.length === 0) { box.innerHTML = ''; box.hidden = true; return; }
+    let html = '<div class="sp-settle-header">💸 結算（你 ↔ 各旅伴的淨額）</div>' +
+      '<ul class="sp-settle-list">' + lines.join('') + '</ul>';
+    if (result.skipped > 0) {
+      html += '<div class="sp-settle-warn">' + result.skipped + ' 筆舊記錄缺少分攤對象資訊，已從結算中略過 — 可編輯後重設「誰要分攤」。</div>';
+    }
+    box.innerHTML = html;
+    box.hidden = false;
+  }
+
   function renderSpending() {
     const summary = document.getElementById('spending-summary');
     const totals = document.getElementById('spending-totals');
@@ -875,6 +1011,7 @@
     totals.innerHTML =
       '<strong>5 日累計：</strong>' + fmtVnd(total) + ' VND' + (totalTwd != null ? ' (NT$ ' + totalTwd.toLocaleString('en-US') + ')' : '') +
       '｜<strong>我的份額：</strong>' + fmtVnd(Math.round(myShare)) + ' VND' + (myShareTwd != null ? ' (NT$ ' + myShareTwd.toLocaleString('en-US') + ')' : '');
+    renderSettlement();
     if (spending.length === 0) {
       list.innerHTML = '<li class="sp-empty">尚無記錄 · 新增第一筆 ↑</li>';
     } else {
@@ -955,6 +1092,15 @@
       activateChipByValue('sp-payer-chips', 'data-payer', memberId);
       updateMultiPayVisibility();
     }
+    // Apply participants → split chips. Fall back to splitCount-derived ids when missing.
+    let pIds = Array.isArray(e.participants) ? e.participants.slice() : [];
+    if (!pIds.length) {
+      const split = Math.max(1, +e.splitCount || 1);
+      const selfId = getSelfMember().id;
+      const others = members.filter((m) => !m.isSelf).map((m) => m.id);
+      pIds = [selfId].concat(others.slice(0, Math.max(0, split - 1)));
+    }
+    setSplitChipsFromIds(pIds);
     syncChipsFromValues();
     updateAmountTwdPreview();
     const submitBtn = document.getElementById('sp-submit');
@@ -1035,23 +1181,75 @@
       if (!matched && customBtn) customBtn.classList.add('active');
     });
   }
-  function setupSplitChips() {
+  function renderSplitChips() {
     const wrap = document.getElementById('sp-split-chips');
     const input = document.getElementById('sp-split');
     if (!wrap || !input) return;
+    // Default: every member is selected (most common case for a group trip).
+    // Edit mode and form reset paths call setSplitChipsFromIds() to override after this.
+    wrap.innerHTML = members.map((m) =>
+      '<button type="button" class="sp-chip sp-split-chip active"' +
+      ' data-mid="' + escapeHtml(m.id) + '"' + (m.isSelf ? ' data-self="1"' : '') + '>' +
+        (m.isSelf ? '🙋 ' : '👤 ') + escapeHtml(m.name) +
+      '</button>'
+    ).join('');
     wrap.querySelectorAll('button').forEach((btn) => {
       btn.addEventListener('click', () => {
-        input.value = btn.dataset.split;
-        wrap.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
-        btn.classList.add('active');
+        // Self chip cannot be deactivated — your share always counts
+        if (btn.dataset.self === '1') {
+          btn.classList.add('active');
+          updateSplitCountFromChips();
+          return;
+        }
+        btn.classList.toggle('active');
+        updateSplitCountFromChips();
       });
     });
+    updateSplitCountFromChips();
+  }
+  function getActiveSplitMemberIds() {
+    const wrap = document.getElementById('sp-split-chips');
+    const selfId = getSelfMember().id;
+    if (!wrap) return [selfId];
+    const ids = Array.from(wrap.querySelectorAll('button.active')).map((b) => b.dataset.mid);
+    if (!ids.includes(selfId)) ids.unshift(selfId);
+    return ids;
+  }
+  function updateSplitCountFromChips() {
+    const ids = getActiveSplitMemberIds();
+    const inp = document.getElementById('sp-split');
+    if (inp) inp.value = String(ids.length);
+    const status = document.getElementById('sp-split-status');
+    if (status) {
+      const amtEl = document.getElementById('sp-amount');
+      const amt = amtEl ? parseInt(amtEl.value, 10) || 0 : 0;
+      if (ids.length <= 1) {
+        status.textContent = '只有你 — 不分攤';
+      } else if (amt > 0) {
+        const share = Math.round(amt / ids.length);
+        const twd = (typeof rate === 'number' && rate) ? ' ≈ NT$ ' + Math.round(share * rate).toLocaleString('en-US') : '';
+        status.textContent = '每人 ' + fmtVnd(share) + ' VND' + twd + '（' + ids.length + ' 人均分）';
+      } else {
+        status.textContent = ids.length + ' 人均分';
+      }
+    }
+  }
+  function setSplitChipsFromIds(ids) {
+    const wrap = document.getElementById('sp-split-chips');
+    if (!wrap) return;
+    const set = new Set(ids || []);
+    const selfId = getSelfMember().id;
+    set.add(selfId); // self always included
+    wrap.querySelectorAll('button').forEach((b) => {
+      if (set.has(b.dataset.mid)) b.classList.add('active');
+      else b.classList.remove('active');
+    });
+    updateSplitCountFromChips();
   }
   function syncChipsFromValues() {
     const daySel = document.getElementById('sp-day');
     const catInput = document.getElementById('sp-category');
     const customBtn = document.getElementById('sp-cat-custom-toggle');
-    const splitInput = document.getElementById('sp-split');
     if (daySel) activateChipByValue('sp-day-chips', 'data-day', daySel.value);
     if (catInput) {
       const matched = activateChipByValue('sp-cat-chips', 'data-cat', catInput.value);
@@ -1062,7 +1260,7 @@
         catInput.hidden = true;
       }
     }
-    if (splitInput) activateChipByValue('sp-split-chips', 'data-split', splitInput.value);
+    updateSplitCountFromChips();
   }
   function updateAmountTwdPreview() {
     const amt = parseInt((document.getElementById('sp-amount') || {}).value, 10) || 0;
@@ -1085,7 +1283,8 @@
   if (spForm) {
     setupDayChips();
     setupCategoryChips();
-    setupSplitChips();
+    renderSplitChips();
+    setSplitChipsFromIds(members.map((m) => m.id));
     const tdy = todayStr();
     const dayEl = document.getElementById('sp-day');
     if (dayEl && DAYS.indexOf(tdy) !== -1) dayEl.value = tdy;
@@ -1098,10 +1297,8 @@
       const cat = document.getElementById('sp-category').value.trim().slice(0, 20);
       const day = document.getElementById('sp-day').value;
       const payer = document.getElementById('sp-payer').value;
-      const splitEl = document.getElementById('sp-split');
-      let split = parseInt(splitEl.value, 10);
-      if (!split || split < 1) split = 1;
-      if (split > 20) split = 20;
+      const participants = getActiveSplitMemberIds();
+      const split = participants.length;
       const noteEl = document.getElementById('sp-note');
       const note = noteEl ? noteEl.value.trim().slice(0, 60) : '';
       if (!amt || amt <= 0) return;
@@ -1130,10 +1327,10 @@
 
       if (editingIdx >= 0 && spending[editingIdx]) {
         const origTs = spending[editingIdx].ts;
-        spending[editingIdx] = { amount: amtFinal, category: cat, day: day, payer: payer, paid: paid, splitCount: split, note: note, ts: origTs };
+        spending[editingIdx] = { amount: amtFinal, category: cat, day: day, payer: payer, paid: paid, splitCount: split, participants: participants, note: note, ts: origTs };
         exitSpendingEditMode();
       } else {
-        spending.push({ amount: amtFinal, category: cat, day: day, payer: payer, paid: paid, splitCount: split, note: note, ts: Date.now() });
+        spending.push({ amount: amtFinal, category: cat, day: day, payer: payer, paid: paid, splitCount: split, participants: participants, note: note, ts: Date.now() });
       }
       saveSpending();
       amtEl.value = '';
@@ -1145,6 +1342,8 @@
         activateChipByValue('sp-payer-chips', 'data-payer', getSelfMember().id);
         updateMultiPayVisibility();
       }
+      // Reset split chips to "all members" so a new entry defaults to whole group
+      setSplitChipsFromIds(members.map((m) => m.id));
       updateAmountTwdPreview();
       renderSpending();
       schedulePush();
@@ -1161,6 +1360,7 @@
           activateChipByValue('sp-payer-chips', 'data-payer', getSelfMember().id);
           updateMultiPayVisibility();
         }
+        setSplitChipsFromIds(members.map((m) => m.id));
         updateAmountTwdPreview();
         renderSpending();
       });
@@ -1169,6 +1369,7 @@
     const amtChange = document.getElementById('sp-amount');
     if (amtChange) amtChange.addEventListener('input', () => {
       updateAmountTwdPreview();
+      updateSplitCountFromChips();
       const ps = document.getElementById('sp-payer');
       if (ps && ps.value === '__multi__') updateMultiPayStatus();
     });

--- a/index.html
+++ b/index.html
@@ -359,7 +359,26 @@
     font-weight: bold;
     color: #001858;
     margin-bottom: 6px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
   }
+  .weather-refresh {
+    background: transparent;
+    border: 1px solid #8bd3dd;
+    color: #001858;
+    border-radius: 12px;
+    width: 26px;
+    height: 22px;
+    font-size: 13px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+  }
+  .weather-refresh:active { transform: scale(0.92); }
+  body.dark .weather-refresh { border-color: #8bd3dd; color: #e8edff; background: rgba(139,211,221,0.1); }
+  @media print { .weather-refresh { display: none; } }
   .weather-days {
     display: grid;
     grid-template-columns: repeat(5, 1fr);
@@ -1462,7 +1481,10 @@
   <a href="#day-5" data-day="5">Day 5<small>5/5 二</small></a>
 </nav>
 <div class="weather-box" id="weather-box">
-  <div class="weather-header">☁️ 5/1–5/5 胡志明天氣</div>
+  <div class="weather-header">
+    <span>☁️ 5/1–5/5 胡志明天氣</span>
+    <button type="button" class="weather-refresh" id="weather-refresh" aria-label="重新整理天氣預報">↻</button>
+  </div>
   <div class="weather-days" id="weather-days" aria-live="polite">載入中…</div>
 </div>
 <div class="progress-wrap" id="progress-wrap">

--- a/index.html
+++ b/index.html
@@ -995,6 +995,64 @@
     font-size: 13px;
   }
   .spending-totals strong { color: #4a8050; }
+  .spending-settle {
+    margin-top: 8px;
+    background: #fff7ec;
+    border: 1px solid #f3d2a8;
+    border-radius: 6px;
+    padding: 10px 12px;
+    font-size: 13px;
+  }
+  .spending-settle .sp-settle-header {
+    font-weight: bold;
+    color: #c46e2c;
+    margin-bottom: 6px;
+    font-size: 13px;
+  }
+  .spending-settle .sp-settle-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .spending-settle .sp-settle-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border-radius: 4px;
+    background: white;
+  }
+  .spending-settle .sp-settle-name { font-weight: 600; color: #333; }
+  .spending-settle .sp-settle-amount { font-weight: 600; }
+  .spending-settle .sp-settle-debt .sp-settle-name::before { content: '↗ '; color: #c14d4d; }
+  .spending-settle .sp-settle-debt .sp-settle-amount { color: #c14d4d; }
+  .spending-settle .sp-settle-credit .sp-settle-name::before { content: '↙ '; color: #4a8050; }
+  .spending-settle .sp-settle-credit .sp-settle-amount { color: #4a8050; }
+  .spending-settle .sp-settle-zero .sp-settle-amount { color: #888; font-weight: 500; }
+  .spending-settle .sp-settle-warn {
+    margin-top: 6px;
+    font-size: 11px;
+    color: #888;
+    font-style: italic;
+  }
+  body.dark .spending-settle { background: #2a2515; border-color: #6a4a2a; }
+  body.dark .spending-settle .sp-settle-header { color: #d6843e; }
+  body.dark .spending-settle .sp-settle-row { background: #1e2a4a; }
+  body.dark .spending-settle .sp-settle-name { color: #d0d8ee; }
+  body.dark .spending-settle .sp-settle-debt .sp-settle-amount { color: #ff8f8f; }
+  body.dark .spending-settle .sp-settle-credit .sp-settle-amount { color: #88c894; }
+  body.dark .spending-settle .sp-settle-warn { color: #98a4be; }
+  .sp-split-status {
+    font-size: 11px;
+    color: #4a6080;
+    margin-top: 4px;
+    min-height: 14px;
+  }
+  body.dark .sp-split-status { color: #98a4be; }
   .spending-list {
     list-style: none;
     padding: 0;
@@ -1619,19 +1677,11 @@
         <div class="sp-mp-status" id="sp-mp-status">請至少輸入一個人付的金額</div>
       </div>
 
-      <!-- Split count chips -->
+      <!-- Split participants (toggleable member chips; count is implicit) -->
       <div class="sp-field" id="sp-split-section">
-        <label class="sp-label">✂️ 幾個人分攤</label>
-        <div class="sp-chip-group sp-chip-split" id="sp-split-chips" role="radiogroup">
-          <button type="button" class="sp-chip" data-split="1">1 人</button>
-          <button type="button" class="sp-chip" data-split="2">2 人</button>
-          <button type="button" class="sp-chip" data-split="3">3 人</button>
-          <button type="button" class="sp-chip" data-split="4">4 人</button>
-          <button type="button" class="sp-chip" data-split="5">5 人</button>
-          <button type="button" class="sp-chip" data-split="6">6 人</button>
-          <button type="button" class="sp-chip" data-split="8">8 人</button>
-          <button type="button" class="sp-chip" data-split="10">10 人</button>
-        </div>
+        <label class="sp-label">✂️ 誰要分攤（可多選）</label>
+        <div class="sp-chip-group sp-chip-split" id="sp-split-chips" role="group" aria-label="分攤對象"></div>
+        <div class="sp-split-status" id="sp-split-status" aria-live="polite"></div>
         <input type="number" id="sp-split" min="1" max="20" step="1" value="1" hidden>
       </div>
 
@@ -1646,6 +1696,7 @@
     </form>
     <div class="spending-summary" id="spending-summary"></div>
     <div class="spending-totals" id="spending-totals"></div>
+    <div class="spending-settle" id="spending-settle" hidden></div>
     <ul class="spending-list" id="spending-list"></ul>
   </div>
 </details>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'saigon-trip-v53';
+const CACHE = 'saigon-trip-v54';
 const ASSETS = ['./', './index.html', './manifest.json', './app.js', './favicon.svg'];
 
 self.addEventListener('install', (e) => {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'saigon-trip-v54';
+const CACHE = 'saigon-trip-v55';
 const ASSETS = ['./', './index.html', './manifest.json', './app.js', './favicon.svg'];
 
 self.addEventListener('install', (e) => {


### PR DESCRIPTION
問題：使用者反映 5/1–5/5 五天天氣預報「不準確」。實際排查到幾個資料源頭與
顯示層的問題會疊加放大誤差：

1. localStorage 的 weather-sgn-v1 是 4 月（甚至更早）就快取下來的資料。
   出發日早於 Open-Meteo 16 天預報視窗時，當時抓到的多半是模型氣候平均
   值，不是真實預報；現在實際預報已經出來了，舊快取卻還會被回退顯示。
   → 把鍵名升到 weather-sgn-v2，強制丟掉舊快取。
2. WMO weather_code 的 emoji 對照表有 bug：
   - 1（晴時多雲）、2（局部多雲）、3（陰天）全部顯示 ⛅，
     使用者在實際是「整天陰天」時看到的是「局部多雲」太陽。
   - c <= 48 把 4–44 這段非 WMO 碼也都導向 🌫️ 霧。
   → 改成嚴格對照 WMO 碼：0☀️ 1🌤️ 2⛅ 3☁️ 45/48🌫️
     51-57🌦️ 61-67🌧️ 71-77❄️ 80-82🌧️ 85-86🌨️ 95+⛈️。
3. 只顯示降雨機率%、不顯示降雨量 mm。胡志明 5 月午後雷陣雨機率動輒 70%+
   但雨可能只下 10 分鐘 1mm；反過來也有低機率但累積雨量可觀的情況。
   → API 多請 precipitation_sum；卡片改為「💧80% · 18mm」雙指標；
     行程日警示也改成 ≥60% 機率 OR ≥5mm 才觸發，並補上預估雨量文字。
4. 沒有「最後更新時間」，使用者無從判斷現在看到的是不是新資料。
   → 卡片底部顯示「更新 5/1 14:32」格式時戳；新增右上角 ↻ 重新整理按鈕，
     按一下會清掉 localStorage 快取並重新打 API。
5. 舊版只在 fetch 失敗時才退回快取；網路慢時會卡在「載入中…」。
   → 進入時若有快取先即時 render（無「離線」標記），再背景 fetch 蓋掉。
   → fetch 失敗才打上「離線快取資料」字樣。

URL 也改為 models=best_match 顯式指定，與預設行為一致但語意清楚，
未來要切到 ECMWF/JMA 直接改一個參數。

驗證：JSDOM 30/30 測試全綠，涵蓋 URL 參數、5 天 emoji 對應、溫度/降雨
顯示、雨量警示觸發條件、重新整理按鈕、舊快取先 render→新資料覆蓋、
離線 fallback 字樣。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>